### PR TITLE
修正不能真正保持token的bug

### DIFF
--- a/lib/wechat/access_token.rb
+++ b/lib/wechat/access_token.rb
@@ -1,3 +1,4 @@
+require 'json'
 module Wechat
   class AccessToken
     attr_reader :client, :appid, :secret, :token_file, :token_data
@@ -19,7 +20,7 @@ module Wechat
     end
 
     def refresh
-      data = client.get("token", params:{grant_type: "client_credential", appid: appid, secret: secret})
+      data = JSON client.get("token", params:{grant_type: "client_credential", appid: appid, secret: secret})
       File.open(token_file, 'w'){|f| f.write(data.to_s)} if valid_token(data)
       return @token_data = data
     end


### PR DESCRIPTION
因为`@token_data ||= JSON.parse(File.read(token_file))`需要json格式的文件，但在`client.get`时已被转换成hash对象了，写入临时文件时，也是hash后的字符串，导致每次`JSON.parse`时发生异常，直接再次从服务器直接获取了
